### PR TITLE
Feature_displayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!--Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.-->
 
+### 2023-05-15
+
+1. Support displayName feature (by [@raven42](https://github.com/raven42))
+
 ### 2021-10-19
 
 1. Support group feature (by [@s19514tt](https://github.com/s19514tt))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "favorites.resources": {
           "type": "array",
           "default": [],
-          "description": "Resources marked as favorites"
+          "description": "Resources marked as favorites. Can optionally update 'displayName' to change the value shown in the tree view."
         },
         "favorites.sortOrder": {
           "type": "string",

--- a/src/command/addToFavorites.ts
+++ b/src/command/addToFavorites.ts
@@ -35,7 +35,7 @@ export function addToFavorites() {
       .save(
         'resources',
         previousResources.concat([
-          { filePath: newResource, group: currentGroup },
+          { filePath: newResource, displayName: newResource, group: currentGroup },
         ] as Array<ItemInSettingsJson>)
       )
       .catch(console.warn)

--- a/src/command/moveDown.ts
+++ b/src/command/moveDown.ts
@@ -12,13 +12,19 @@ export function moveDown(favoritesProvider: FavoritesProvider) {
     const items = await getCurrentResources()
     const filteredArray: {
       filePath: string
+      displayName: string
       group: string
       previousIndex: number
     }[] = []
 
     items.forEach((value, index) => {
       if (value.group == currentGroup) {
-        filteredArray.push({ filePath: value.filePath, group: value.group, previousIndex: index })
+        filteredArray.push({
+          filePath: value.filePath,
+          displayName: value.displayName,
+          group: value.group,
+          previousIndex: index
+        })
       }
     })
 

--- a/src/command/moveToBottom.ts
+++ b/src/command/moveToBottom.ts
@@ -12,13 +12,19 @@ export function moveToBottom(favoritesProvider: FavoritesProvider) {
     const items = await getCurrentResources()
     const filteredArray: {
       filePath: string
+      displayName: string
       group: string
       previousIndex: number
     }[] = []
 
     items.forEach((value, index) => {
       if (value.group == currentGroup) {
-        filteredArray.push({ filePath: value.filePath, group: value.group, previousIndex: index })
+        filteredArray.push({
+          filePath: value.filePath,
+          displayName: value.displayName,
+          group: value.group,
+          previousIndex: index
+        })
       }
     })
 

--- a/src/command/moveToTop.ts
+++ b/src/command/moveToTop.ts
@@ -12,13 +12,19 @@ export function moveToTop(favoritesProvider: FavoritesProvider) {
     const items = await getCurrentResources()
     const filteredArray: {
       filePath: string
+      displayName: string
       group: string
       previousIndex: number
     }[] = []
 
     items.forEach((value, index) => {
       if (value.group == currentGroup) {
-        filteredArray.push({ filePath: value.filePath, group: value.group, previousIndex: index })
+        filteredArray.push({
+          filePath: value.filePath,
+          displayName: value.displayName,
+          group: value.group,
+          previousIndex: index
+        })
       }
     })
 

--- a/src/command/moveUp.ts
+++ b/src/command/moveUp.ts
@@ -12,13 +12,19 @@ export function moveUp(favoritesProvider: FavoritesProvider) {
     const items = await getCurrentResources()
     const filteredArray: {
       filePath: string
+      displayName: string
       group: string
       previousIndex: number
     }[] = []
 
     items.forEach((value, index) => {
       if (value.group == currentGroup) {
-        filteredArray.push({ filePath: value.filePath, group: value.group, previousIndex: index })
+        filteredArray.push({
+          filePath: value.filePath,
+          displayName: value.displayName,
+          group: value.group,
+          previousIndex: index
+        })
       }
     })
 

--- a/src/helper/util.ts
+++ b/src/helper/util.ts
@@ -28,7 +28,7 @@ export function getCurrentResources(): Array<ItemInSettingsJson> {
   const resources = (configMgr.get('resources') as Array<ItemInSettingsJson | string>) || []
   const newResources: Array<ItemInSettingsJson> = resources.map((item) => {
     if (typeof item == 'string') {
-      return { filePath: item, group: DEFAULT_GROUP } as ItemInSettingsJson
+      return { filePath: item, displayName: item, group: DEFAULT_GROUP } as ItemInSettingsJson
     } else {
       return item
     }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -3,6 +3,7 @@ import { Uri } from 'vscode';
 
 export interface Item {
     filePath: string;
+    displayName: string;
     stat: FileStat;
     group:string;
     uri?: Uri;
@@ -10,5 +11,6 @@ export interface Item {
 
 export interface ItemInSettingsJson {
     filePath:string;
+    displayName:string;
     group:string;
 }


### PR DESCRIPTION
Add option for `displayName` to change the value displayed in the tree view. This can be useful when creating favorites for different subdirectories that exist in different paths but have the same name. For example:
```
/project/
    /module/
    /lib/
        /module/
```